### PR TITLE
add GITHUB_TOKEN permissions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ on:
   pull_request:
     paths:
       - 'path/to/migration/dir/*'
+# Permissions to write comments on the pull request.
+permissions:
+  contents: read
+  pull-requests: write
 jobs:
   lint:
     services:


### PR DESCRIPTION
default permissions for GITHUB_TOKEN does not include` write on PR` permission
since month ago: https://github.blog/changelog/2023-02-02-github-actions-updating-the-default-github_token-permissions-to-read-only/#:~:text=Previously%2C%20GitHub%20Actions%20gets%20a,to%20read%2Fwrite%20if%20needed. 

see default permissions on new repo:

https://user-images.githubusercontent.com/63970571/226176389-d6b0bf9b-6235-4b2a-b7ea-88c0f356945e.mov



Thus, with default permissions users get an `Resource not accessible by integration` Error
see failing: https://github.com/ronenlu/test_migration/actions/runs/4434852193/jobs/7781295191#step:3:69

but with the permissions specified in the README the workflow is green,
 see working: https://github.com/ronenlu/test_migration/actions/runs/4460538212/jobs/7833748560?pr=3
 
 
 next: need to update README of atlas-sync action and nebula UI