### PR TITLE
migrate/lint: change github-token to an env var instead of an input parameter

### DIFF
--- a/.github/workflows/ci-go.yaml
+++ b/.github/workflows/ci-go.yaml
@@ -82,6 +82,8 @@ jobs:
           dir: file://atlasaction/testdata/migrations
           dev-url: sqlite://file.db?mode=memory
           dir-name: test_dir
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
       - id: lint_failure
         uses: ./migrate/lint
         continue-on-error: true
@@ -89,6 +91,8 @@ jobs:
           dir: file://atlasaction/testdata/migrations_destructive
           dev-url: sqlite://file.db?mode=memory
           dir-name: test-dir
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
       - id: check-lint-failure
         if: steps.lint_failure.outcome == 'success'
         uses: actions/github-script@v3

--- a/atlasaction/action.go
+++ b/atlasaction/action.go
@@ -156,7 +156,7 @@ func publishResult(url string, err error, act *githubactions.Action) error {
 	if prNumber == 0 {
 		return nil
 	}
-	ghToken := act.GetInput("github-token")
+	ghToken := act.Getenv("GITHUB_TOKEN")
 	comments, err := g.getIssueComments(prNumber, event.Repository.Name, ghToken)
 	if err != nil {
 		return err

--- a/atlasaction/action_test.go
+++ b/atlasaction/action_test.go
@@ -420,7 +420,7 @@ func TestMigrateLint(t *testing.T) {
 			"repository": { "name": "test-repository" }
 		}`)
 		tt.setupConfigWithLogin(t, srv.URL, token)
-		tt.setInput("github-token", "very-secret-gh-token")
+		tt.env["GITHUB_TOKEN"] = "very-secret-gh-token"
 		tt.setInput("dev-url", "sqlite://file?mode=memory")
 		tt.setInput("dir", "file://testdata/migrations")
 		tt.setInput("dir-name", "test-dir-slug")

--- a/migrate/lint/action.yml
+++ b/migrate/lint/action.yml
@@ -19,9 +19,6 @@ inputs:
   env:
     description: The environment to use with the configuration file.
     required: false
-  github-token:
-    description: The github token
-    default: ${{ github.token }}
 runs:
   using: node20
   main: dist/index.js


### PR DESCRIPTION
This change aligns the way the token is passed around to the rest of the actions online

The default value of the token was only working from inside the organization