### PR TITLE
build: fix build after SDK upgrade

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -39,6 +39,9 @@ jobs:
           go build -o $BINARY_NAME -ldflags "-X ariga.io/atlas-action/atlasaction.Version=${{ github.event.inputs.version || 'v1' }}" ./cmd/atlas-action
         env:
           CGO_ENABLED: 0
+      - name: Install Atlas
+        uses: ariga/setup-atlas@v0
+
       - name: Check version
         run: |
           OUTPUT=$(./$BINARY_NAME --version)


### PR DESCRIPTION
The build was failing because the SDK now verifies that Atlas is installed