### PR TITLE
atlasaction: fixed comment icons size on mobile

### DIFF
--- a/atlasaction/comment.tmpl
+++ b/atlasaction/comment.tmpl
@@ -3,7 +3,7 @@
 <table>
     <thead>
         <tr>
-            <th></th>
+            <th>Status</th>
             <th>Step</th>
             <th>Link</th>
         </tr>
@@ -11,7 +11,7 @@
     <tbody>
         <tr>
             <td>
-                <img src="https://release.ariga.io/images/assets/success.svg"/>
+                <img width="20px" height="21px" src="https://release.ariga.io/images/assets/success.svg"/>
             </td>
             <td>
                 {{- $fileCount := len .Files }}
@@ -21,7 +21,7 @@
         </tr>
         <tr>
             <td>
-                <img src="https://release.ariga.io/images/assets/success.svg"/>
+                <img width="20px" height="21px" src="https://release.ariga.io/images/assets/success.svg"/>
             </td>
             <td>
                 ERD and Visual Diff generated
@@ -34,21 +34,21 @@
             {{- $errCount := fileErrors .}}
             {{- if gt $errCount 0 }}
             <td>
-                <img src="https://release.ariga.io/images/assets/error.svg"/>
+                <img width="20px" height="21px" src="https://release.ariga.io/images/assets/error.svg"/>
             </td>
             <td>
                 {{ $errCount }} error{{ if gt $errCount 1}}s{{ end }} found
             </td>
             {{- else if .DiagnosticsCount }}
             <td>
-                <img src="https://release.ariga.io/images/assets/warning.svg"/>
+                <img width="20px" height="21px" src="https://release.ariga.io/images/assets/warning.svg"/>
             </td>
             <td>
                 {{ .DiagnosticsCount }} issue{{ if gt .DiagnosticsCount 1}}s{{ end }} found
             </td>
             {{- else}}
             <td>
-                <img src="https://release.ariga.io/images/assets/success.svg"/>
+                <img width="20px" height="21px" src="https://release.ariga.io/images/assets/success.svg"/>
             </td>
             <td>
                 No issues found.


### PR DESCRIPTION
fixes #110 