### PR TITLE
compare whole file path when checking for pr files

### DIFF
--- a/atlasaction/action_test.go
+++ b/atlasaction/action_test.go
@@ -387,7 +387,7 @@ func TestMigrateLint(t *testing.T) {
 				return
 			// List pull request files endpoint
 			case path == "/repos/test-owner/test-repository/pulls/0/files" && method == http.MethodGet:
-				_, err := writer.Write([]byte(`[{"filename": "20230925192914.sql"}]`))
+				_, err := writer.Write([]byte(`[{"filename": "testdata/migrations_destructive/20230925192914.sql"}]`))
 				require.NoError(t, err)
 			default:
 				writer.WriteHeader(http.StatusNotFound)
@@ -559,7 +559,7 @@ func TestMigrateLint(t *testing.T) {
 				writer.WriteHeader(http.StatusCreated)
 			// List pull request files endpoint
 			case path == "/repos/test-owner/test-repository/pulls/42/files" && method == http.MethodGet:
-				_, err := writer.Write([]byte(`[{"filename": "20230925192914.sql"}]`))
+				_, err := writer.Write([]byte(`[{"filename": "testdata/migrations_destructive/20230925192914.sql"}]`))
 				require.NoError(t, err)
 			}
 		}))


### PR DESCRIPTION
appernlty GitHub sends the complete file path in the filename field:
![image](https://github.com/ariga/atlas-action/assets/63970571/20705f9d-4e93-47ac-ac35-573d59cec083)
