### PR TITLE
fix not sending url in conext

### DIFF
--- a/atlasaction/action.go
+++ b/atlasaction/action.go
@@ -616,6 +616,7 @@ type githubTriggerEvent struct {
 		Number int `mapstructure:"number"`
 		Head   struct {
 			SHA string `mapstructure:"sha"`
+			URL string `mapstructure:"url"`
 		} `mapstructure:"head"`
 	} `mapstructure:"pull_request"`
 }
@@ -626,6 +627,7 @@ func triggerEvent(ghContext *githubactions.GitHubContext) (*githubTriggerEvent, 
 	if err := mapstructure.Decode(ghContext.Event, &event); err != nil {
 		return nil, fmt.Errorf("failed to parse push event: %v", err)
 	}
+	fmt.Printf("event: %+v\n", event)
 	return &event, nil
 }
 

--- a/atlasaction/action_test.go
+++ b/atlasaction/action_test.go
@@ -258,12 +258,17 @@ func TestMigrateE2E(t *testing.T) {
 	require.NoError(t, err)
 	err = os.Setenv("GITHUB_ACTOR_ID", "123")
 	require.NoError(t, err)
+	tt.setEvent(t, `{
+			"pull_request": {
+				"html_url": "http://test"
+			}
+		}`)
 	expected := &atlasexec.RunContext{
 		Repo:     "repository",
 		Path:     "file://testdata/migrations",
 		Branch:   "testing-branch",
 		Commit:   "sha1234",
-		URL:      "",
+		URL:      "http://test",
 		Username: "test-user",
 		UserID:   "123",
 		SCMType:  "GITHUB",


### PR DESCRIPTION
currently we dont send anything in the url field of the atlas context,
since we use head_commit_url field which is always empty:
<img width="1335" alt="Screen Shot 2024-02-29 at 17 23 54" src="https://github.com/ariga/atlas-action/assets/63970571/d46001e8-c86a-4aa5-b6c1-c160b04f4c4b">
