### PR TITLE
.github: update go version in unit-tests action

### DIFF
--- a/.github/workflows/ci-go.yaml
+++ b/.github/workflows/ci-go.yaml
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
+          go-version: '1.22'
       - name: Run tests
         run: go test -race ./...
   integration-test:

--- a/.github/workflows/ci-go.yaml
+++ b/.github/workflows/ci-go.yaml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.22'
+          go-version-file: go.mod
       - name: Run Go linters
         uses: golangci/golangci-lint-action@v3
         with:
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.22'
+          go-version-file: go.mod
       - name: Run tests
         run: go test -race ./...
   integration-test:
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.22'
+          go-version-file: go.mod
       - run: go install ./cmd/atlas-action
         env:
           CGO_ENABLED: 0
@@ -113,7 +113,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.22'
+          go-version-file: go.mod
       - run: go install ./cmd/atlas-action
         env:
           CGO_ENABLED: 0


### PR DESCRIPTION
fix failing unit tests [job](https://github.com/ariga/atlas-action/actions/runs/8433685168/job/23095256129#step:4:60):
![image](https://github.com/ariga/atlas-action/assets/63970571/7d9c2071-ce11-4a47-b667-e73b3c41a60c)
