### PR TITLE
fix not showing error indaction for checksum mismatch atlas payload

### DIFF
--- a/atlasaction/action.go
+++ b/atlasaction/action.go
@@ -308,6 +308,15 @@ func fileErrors(s *atlasexec.SummaryReport) int {
 	return count
 }
 
+func firstError(s *atlasexec.SummaryReport) string {
+	for _, f := range s.Files {
+		if len(f.Error) > 0 {
+			return f.Error
+		}
+	}
+	return ""
+}
+
 var (
 	//go:embed comment.tmpl
 	commentTmpl string
@@ -315,6 +324,7 @@ var (
 		template.New("comment").
 			Funcs(template.FuncMap{
 				"fileErrors": fileErrors,
+				"firstError": firstError,
 			}).
 			Parse(commentTmpl),
 	)

--- a/atlasaction/action_test.go
+++ b/atlasaction/action_test.go
@@ -1121,6 +1121,67 @@ func TestTemplateGeneration(t *testing.T) {
     </tbody>
 </table>`,
 		},
+		{
+			name: "checksum error",
+			payload: &atlasexec.SummaryReport{
+				URL: "https://migration-lint-report-url",
+				Env: env{
+					Dir: "testdata/migrations",
+				},
+				Files: []*atlasexec.FileReport{{
+					Error: "checksum mismatch",
+				}},
+			},
+			// language=html
+			expected: `<table>
+    <thead>
+        <tr>
+            <th>Status</th>
+            <th>Step</th>
+            <th>Link</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>
+                <div align="center">
+                    <img width="20px" height="21px" src="https://release.ariga.io/images/assets/success.svg"/>
+                </div>
+            </td>
+            <td>
+                1 new migration file detected
+            </td>
+            <td>&nbsp;</td>
+        </tr>
+        <tr>
+            <td>
+                <div align="center">
+                    <img width="20px" height="21px" src="https://release.ariga.io/images/assets/success.svg"/>
+                </div>
+            </td>
+            <td>
+                ERD and visual diff generated
+            </td>
+            <td>
+                <a href="https://migration-lint-report-url#erd" target="_blank">View Visualization</a>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div align="center">
+                    <img width="20px" height="21px" src="https://release.ariga.io/images/assets/error.svg"/>
+                </div>
+            </td>
+            <td>
+                1 error found
+            </td>
+            <td>
+                <a href="https://migration-lint-report-url" target="_blank">View Report</a>
+            </td>
+        </tr>
+    </tbody>
+</table>`,
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			var buf bytes.Buffer

--- a/atlasaction/action_test.go
+++ b/atlasaction/action_test.go
@@ -1173,7 +1173,7 @@ func TestTemplateGeneration(t *testing.T) {
                 </div>
             </td>
             <td>
-                1 error found
+                checksum mismatch
             </td>
             <td>
                 <a href="https://migration-lint-report-url" target="_blank">View Report</a>

--- a/atlasaction/comment.tmpl
+++ b/atlasaction/comment.tmpl
@@ -51,8 +51,10 @@
             <td>
                 {{- if .DiagnosticsCount }}
                 {{ .DiagnosticsCount }} issue{{ if gt .DiagnosticsCount 1}}s{{ end }} {{ if gt .DiagnosticsCount 1}}were{{ else }}was{{ end }} found
-                {{- else }}
-                {{ $errCount }} error{{ if gt $errCount 1}}s{{ end }} found
+                {{- else if eq $errCount 1}}
+                {{ firstError . }}
+                {{- else}}
+                {{ $errCount }} errors were found
                 {{- end }}
             </td>
             {{- else}}

--- a/atlasaction/comment.tmpl
+++ b/atlasaction/comment.tmpl
@@ -35,9 +35,9 @@
             </td>
         </tr>
         <tr>
-            {{- if .DiagnosticsCount }}
+            {{- $errCount := fileErrors .}}
+            {{- if or (gt $errCount 0) (gt .DiagnosticsCount 0) }}
             <td>
-                {{- $errCount := fileErrors .}}
                 {{- if gt $errCount 0 }}
                 <div align="center">
                     <img width="20px" height="21px" src="https://release.ariga.io/images/assets/error.svg"/>
@@ -49,7 +49,11 @@
                 {{- end }}
             </td>
             <td>
+                {{- if .DiagnosticsCount }}
                 {{ .DiagnosticsCount }} issue{{ if gt .DiagnosticsCount 1}}s{{ end }} {{ if gt .DiagnosticsCount 1}}were{{ else }}was{{ end }} found
+                {{- else }}
+                {{ $errCount }} error{{ if gt $errCount 1}}s{{ end }} found
+                {{- end }}
             </td>
             {{- else}}
             <td>


### PR DESCRIPTION
looks like this:

<table>
    <thead>
        <tr>
            <th>Status</th>
            <th>Step</th>
            <th>Link</th>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <div align="center">
                    <img width="20px" height="21px" src="https://release.ariga.io/images/assets/success.svg"/>
                </div>
            </td>
            <td>
                1 new migration file detected
            </td>
            <td>&nbsp;</td>
        </tr>
        <tr>
            <td>
                <div align="center">
                    <img width="20px" height="21px" src="https://release.ariga.io/images/assets/success.svg"/>
                </div>
            </td>
            <td>
                ERD and visual diff generated
            </td>
            <td>
                <a href="https://migration-lint-report-url#erd" target="_blank">View Visualization</a>
            </td>
        </tr>
        <tr>
            <td>
                <div align="center">
                    <img width="20px" height="21px" src="https://release.ariga.io/images/assets/error.svg"/>
                </div>
            </td>
            <td>
                checksum mismatch
            </td>
            <td>
                <a href="https://migration-lint-report-url" target="_blank">View Report</a>
            </td>
        </tr>
    </tbody>
</table>