### PR TITLE
add non linear history to lint summary report

### DIFF
--- a/atlasaction/action.go
+++ b/atlasaction/action.go
@@ -395,7 +395,24 @@ func hasComments(s *atlasexec.SummaryReport) bool {
 			return true
 		}
 	}
+	for _, step := range s.Steps {
+		if stepHasComments(step) {
+			return true
+		}
+	}
 	return false
+}
+
+// Returns true if the step has diagnostics or comments.
+func stepHasComments(s *atlasexec.StepReport) bool {
+	// Checksum reported on altas.sum file, so no need to report it again.
+	if s.Error != "" && s.Error != "checksum mismatch" {
+		return true
+	}
+	if s.Result == nil {
+		return false
+	}
+	return s.Result.Error != "" || len(s.Result.Reports) > 0
 }
 
 func execTime(start, end time.Time) string {
@@ -427,6 +444,7 @@ var (
 		template.New("comment").
 			Funcs(template.FuncMap{
 				"hasComments":         hasComments,
+				"stepHasComments":     stepHasComments,
 				"fileDiagnosticCount": fileDiagnosticCount,
 			}).
 			Parse(commentTmpl),

--- a/atlasaction/action_test.go
+++ b/atlasaction/action_test.go
@@ -1003,6 +1003,12 @@ func TestLintTemplateGeneration(t *testing.T) {
 				Env: env{
 					Dir: "testdata/migrations",
 				},
+				Steps: []*atlasexec.StepReport{
+					{
+						Name: "Migration Integrity Check",
+						Text: "File atlas.sum is valid",
+					},
+				},
 				Files: []*atlasexec.FileReport{{
 					Name: "20230925192914.sql",
 					Reports: []sqlcheck.Report{
@@ -1181,6 +1187,13 @@ func TestLintTemplateGeneration(t *testing.T) {
 				Env: env{
 					Dir: "testdata/migrations",
 				},
+				Steps: []*atlasexec.StepReport{
+					{
+						Name:  "Migration Integrity Check",
+						Text:  "File atlas.sum is invalid",
+						Error: "checksum mismatch",
+					},
+				},
 				Files: []*atlasexec.FileReport{{
 					Name:  "20230925192914.sql",
 					Error: "checksum mismatch",
@@ -1232,6 +1245,91 @@ func TestLintTemplateGeneration(t *testing.T) {
             </td>
             <td>
                 checksum mismatch
+            </td>
+        </tr>
+    <td colspan="4">
+        <div align="center">
+            Read the full linting report on <a href="https://migration-lint-report-url" target="_blank">Atlas Cloud</a>
+        </div>
+    </td>
+    </tbody>
+</table>`,
+		},
+		{
+			name: "non linear history error",
+			payload: &atlasexec.SummaryReport{
+				URL: "https://migration-lint-report-url",
+				Env: env{
+					Dir: "testdata/migrations",
+				},
+				Steps: []*atlasexec.StepReport{
+					{
+						Name: "Migration Integrity Check",
+						Text: "File atlas.sum is valid",
+					},
+					{
+						Name: "Detected 1 non-additive change",
+						Text: "Pulling the the latest git changes might fix this warning",
+						Result: &atlasexec.FileReport{
+							Reports: []sqlcheck.Report{
+								{
+									Diagnostics: []sqlcheck.Diagnostic{
+										{
+											Pos:  0,
+											Text: "File 20240613102407.sql is missing or has been removed. Changes that have already been applied will not be reverted",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			// language=html
+			expected: `<table>
+    <thead>
+        <tr>
+            <th>Status</th>
+            <th>Step</th>
+            <th>Result</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>
+                <div align="center">
+                    <img width="20px" height="21px" src="https://release.ariga.io/images/assets/success.svg"/>
+                </div>
+            </td>
+            <td>
+                0 new migration files detected
+            </td>
+            <td>&nbsp;</td>
+        </tr>
+        <tr>
+            <td>
+                <div align="center">
+                    <img width="20px" height="21px" src="https://release.ariga.io/images/assets/success.svg"/>
+                </div>
+            </td>
+            <td>
+                ERD and visual diff generated
+            </td>
+            <td>
+                <a href="https://migration-lint-report-url#erd" target="_blank">View Visualization</a>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div align="center">
+                    <img width="20px" height="21px" src="https://release.ariga.io/images/assets/warning.svg"/>
+                </div>
+            </td>
+            <td>
+                Detected 1 non-additive change
+            </td>
+            <td>
+                File 20240613102407.sql is missing or has been removed. Changes that have already been applied will not be reverted <br/>
             </td>
         </tr>
     <td colspan="4">
@@ -1363,10 +1461,10 @@ func TestApplyTemplateGeneration(t *testing.T) {
 							"create Table Err?",
 						},
 						Error: &struct {
-							Stmt  string
+							Stmt string
 							Text string
 						}{
-							Stmt:   "create Table Err?",
+							Stmt: "create Table Err?",
 							Text: "Error 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '?' at line 1",
 						},
 					},

--- a/atlasaction/comments/lint.tmpl
+++ b/atlasaction/comments/lint.tmpl
@@ -51,7 +51,7 @@
         {{- end }}
     {{- if hasComments . }}
     {{- range $file := .Files }}
-    {{- $hasError := $file.Error }}
+        {{- $hasError := $file.Error }}
         <tr>
             <td>
                 {{- if $hasError }}
@@ -87,7 +87,40 @@
             {{- end }}
             </td>
         </tr>
+    {{- end }}
+
+    {{- range $step := .Steps }}
+        {{- if stepHasComments $step }}
+        <tr>
+            <td>
+                {{- $hasError := $step.Error }}
+                {{- if $hasError }}
+                <div align="center">
+                    <img width="20px" height="21px" src="https://release.ariga.io/images/assets/error.svg"/>
+                </div>
+                {{- else }}
+                <div align="center">
+                    <img width="20px" height="21px" src="https://release.ariga.io/images/assets/warning.svg"/>
+                </div>
+                {{- end }}
+            </td>
+            <td>
+                {{ $step.Name }}
+            </td>
+            <td>
+            {{- if $hasError }}
+                {{ $step.Error }}
+            {{- else if $step.Result }}
+                {{- range $step.Result.Reports }}
+                {{- range .Diagnostics }}
+                {{ .Text }} <br/>
+                {{- end }}
+                {{- end }}
+            {{- end }}
+            </td>
+        </tr>
         {{- end }}
+    {{- end }}
     {{- end }}
     <td colspan="4">
         <div align="center">


### PR DESCRIPTION
`atlas migrate lint` on <strong>testdata/migrations</strong>

<table>
    <thead>
        <tr>
            <th>Status</th>
            <th>Step</th>
            <th>Result</th>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>
                <div align="center">
                    <img width="20px" height="21px" src="https://release.ariga.io/images/assets/success.svg"/>
                </div>
            </td>
            <td>
                0 new migration files detected
            </td>
            <td>&nbsp;</td>
        </tr>
        <tr>
            <td>
                <div align="center">
                    <img width="20px" height="21px" src="https://release.ariga.io/images/assets/success.svg"/>
                </div>
            </td>
            <td>
                ERD and visual diff generated
            </td>
            <td>
                <a href="https://migration-lint-report-url#erd" target="_blank">View Visualization</a>
            </td>
        </tr>
        <tr>
            <td>
                <div align="center">
                    <img width="20px" height="21px" src="https://release.ariga.io/images/assets/warning.svg"/>
                </div>
            </td>
            <td>
                Detected 1 non-additive change
            </td>
            <td>
                File 20240613102407.sql is missing or has been removed. Changes that have already been applied will not be reverted <br/>
            </td>
        </tr>
    <td colspan="4">
        <div align="center">
            Read the full linting report on <a href="https://migration-lint-report-url" target="_blank">Atlas Cloud</a>
        </div>
    </td>
    </tbody>
</table>