### PR TITLE
fix template not sowing correct icon on error

### DIFF
--- a/atlasaction/action.go
+++ b/atlasaction/action.go
@@ -471,6 +471,16 @@ func stepHasComments(s *atlasexec.StepReport) bool {
 	return s.Result.Error != "" || len(s.Result.Reports) > 0
 }
 
+func stepHasErrors(s *atlasexec.StepReport) bool {
+	if s.Error != "" {
+		return true
+	}
+	if s.Result == nil {
+		return false
+	}
+	return s.Result.Error != ""
+}
+
 func execTime(start, end time.Time) string {
 	return end.Sub(start).String()
 }
@@ -493,6 +503,7 @@ var (
 			Funcs(template.FuncMap{
 				"hasComments":     hasComments,
 				"stepHasComments": stepHasComments,
+				"stepHasErrors":   stepHasErrors,
 			}).
 			Parse(commentTmpl),
 	)

--- a/atlasaction/action_test.go
+++ b/atlasaction/action_test.go
@@ -1318,8 +1318,8 @@ func TestLintTemplateGeneration(t *testing.T) {
 					{
 						Name:  "Analyze 20240625104520_destructive.sql",
 						Text:  "1 reports were found in analysis",
-						Error: "Destructive changes detected",
 						Result: &atlasexec.FileReport{
+							Error: "Destructive changes detected",
 							Name: "20240625104520_destructive.sql",
 							Text: "DROP TABLE Persons;\n\n",
 							Reports: []sqlcheck.Report{

--- a/atlasaction/comments/lint.tmpl
+++ b/atlasaction/comments/lint.tmpl
@@ -54,8 +54,7 @@
         {{- if stepHasComments $step }}
         <tr>
             <td>
-                {{- $hasError := $step.Error }}
-                {{- if $hasError }}
+                {{- if stepHasErrors $step }}
                 <div align="center">
                     <img width="20px" height="21px" src="https://release.ariga.io/images/assets/error.svg"/>
                 </div>
@@ -69,7 +68,7 @@
                 {{ $step.Name }} <br/> {{ $step.Text }}
             </td>
             <td>
-            {{- if and $hasError (not $step.Result) }}
+            {{- if and $step.Error (not $step.Result) }}
                 {{ $step.Error }}
             {{- else if $step.Result }}
                 {{- range $step.Result.Reports }}


### PR DESCRIPTION
rendered  <img width="20px" height="21px" src="https://release.ariga.io/images/assets/warning.svg"/>
instead of  <img width="20px" height="21px" src="https://release.ariga.io/images/assets/error.svg"/>

I ignored errors on the `Payload.Steps[0].Result.Error` when rendering the Icon, just checked for`Payload.Steps[0].Error`