### PR TITLE
atlasaction/comments: use br tag instead of ul list to present files

### DIFF
--- a/atlasaction/action_test.go
+++ b/atlasaction/action_test.go
@@ -1198,7 +1198,7 @@ func TestLintTemplateGeneration(t *testing.T) {
             <td>
                 1 new migration file detected
             </td>
-            <td><ul><li>20230925192914.sql</li></ul>
+            <td>20230925192914.sql
             </td>
         </tr>
         <tr>
@@ -1312,7 +1312,7 @@ func TestLintTemplateGeneration(t *testing.T) {
             <td>
                 1 new migration file detected
             </td>
-            <td><ul><li>20230925192914.sql</li></ul>
+            <td>20230925192914.sql
             </td>
         </tr>
         <tr>
@@ -1444,7 +1444,7 @@ func TestLintTemplateGeneration(t *testing.T) {
             <td>
                 2 new migration files detected
             </td>
-            <td><ul><li>20230925192914.sql</li><li>20230925192915.sql</li></ul>
+            <td>20230925192914.sql<br/>20230925192915.sql
             </td>
         </tr>
         <tr>
@@ -1532,7 +1532,7 @@ func TestLintTemplateGeneration(t *testing.T) {
             <td>
                 1 new migration file detected
             </td>
-            <td><ul><li>20230925192914.sql</li></ul>
+            <td>20230925192914.sql
             </td>
         </tr>
         <tr>

--- a/atlasaction/comments/lint.tmpl
+++ b/atlasaction/comments/lint.tmpl
@@ -19,7 +19,7 @@
                 {{- $fileCount := len .Files }}
                 {{ if $fileCount }}{{ $fileCount }} new{{ else }}No{{ end }} migration file{{ if ne $fileCount 1 }}s{{ end }} detected
             </td>
-            <td>{{ if not .Files }}&nbsp;{{ else }}<ul>{{ range .Files }}<li>{{ .Name }}</li>{{ end }}</ul>{{ end }}
+            <td>{{ if not .Files }}&nbsp;{{ else }}{{ range $i, $f := .Files }}{{ if $i }}<br/>{{ end }}{{ $f.Name }}{{ end }}{{ end }}
             </td>
         </tr>
         <tr>


### PR DESCRIPTION
This:
<img width="940" alt="image" src="https://github.com/user-attachments/assets/cae44772-9f16-478b-ad88-c3cb42a4cb6b">
Instead of:
<img width="893" alt="image" src="https://github.com/user-attachments/assets/7c453fdd-821c-4a84-92f8-d51d42426162">

