### PR TITLE
.github: build binary on tag, branch pushes

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -11,6 +11,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - 'v*'
 jobs:
   test:
     uses: ./.github/workflows/ci-go.yaml
@@ -19,6 +21,8 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
+      - name: Install Atlas
+        uses: ariga/setup-atlas@v0
       - name: Checkout code
         uses: actions/checkout@v3.0.2
         with:
@@ -30,42 +34,37 @@ jobs:
       - name: Set BINARY_NAME
         id: set_binary_name
         env:
-          VERSION: ${{ github.event.inputs.version || 'v1' }}
+          VERSION: ${{ github.event.inputs.version || github.ref_name }}
         run: |
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "BINARY_NAME=atlas-action-$VERSION" >> $GITHUB_ENV
       - name: Compile Go Binary
         run: |
-          go build -o $BINARY_NAME -ldflags "-s -w -X ariga.io/atlas-action/atlasaction.Version=${{ github.event.inputs.version || 'v1' }}" ./cmd/atlas-action
+          COMMIT=$(git rev-parse --short HEAD)
+          go build -o atlas-action -ldflags "-s -w -X main.version=$VERSION main.commit=$COMMIT" ./cmd/atlas-action
+          OUTPUT=$(./atlas-action --version)
+          [ $(echo $OUTPUT | grep -i "^$VERSION") ] && echo Version=$OUTPUT || (echo "unexpected output: $OUTPUT, expected: $VERSION"; exit 1)
         env:
           CGO_ENABLED: 0
-      - name: Install Atlas
-        uses: ariga/setup-atlas@v0
-
-      - name: Check version
-        run: |
-          OUTPUT=$(./$BINARY_NAME --version)
-          [ $(echo $OUTPUT | grep -i "^$VERSION") ] && echo Version=$OUTPUT || (echo "unexpected output: $OUTPUT, expected: $VERSION"; exit 1)
       - name: Configure AWS credentials
         run: |
           aws configure set aws_access_key_id ${{ secrets.RELEASE_AWS_ACCESS_KEY_ID }}
           aws configure set aws_secret_access_key ${{ secrets.RELEASE_AWS_SECRET_ACCESS_KEY }}
       - name: Upload binary to S3
+        run: |
+          aws s3 cp ./atlas-action s3://release.ariga.io/atlas-action/$BINARY_NAME
         env:
           AWS_REGION: us-east-1
-        run: |
-          aws s3 cp $BINARY_NAME s3://release.ariga.io/atlas-action/$BINARY_NAME
-
   # Run end-to-end test on the published binary.
   e2e-test:
     needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ariga/setup-atlas@master
+      - uses: ariga/setup-atlas@v0
         with:
           cloud-token: ${{ secrets.ATLAS_TOKEN }}
-      - name: "Run Migrate Lint"
+      - name: Run Migrate Lint
         env:
           GITHUB_TOKEN: ${{ github.token }}
         uses: jenseng/dynamic-uses@v1
@@ -76,8 +75,7 @@ jobs:
             "dev-url": "sqlite://dev?mode=memory",
             "dir-name": "test-dir-sqlite"
             }'
-
-      - name: "Run Migrate Push"
+      - name: Run Migrate Push
         uses: jenseng/dynamic-uses@v1
         with:
           uses: ariga/atlas-action/migrate/push@${{ github.event.inputs.version || 'v1' }}

--- a/atlasaction/action.go
+++ b/atlasaction/action.go
@@ -25,15 +25,12 @@ import (
 	"github.com/sethvargo/go-envconfig"
 )
 
-// Version holds atlas-action version. When built with cloud packages should be set by build flag, e.g.
-// "-X 'ariga.io/atlas-action/atlasaction.Version=v0.1.2'"
-var Version string
-
 // Actions holds the runtime for the actions to run.
 // This helps to inject the runtime dependencies. Like the SCM client, Atlas client, etc.
 type Actions struct {
 	Action
-	Atlas AtlasExec
+	Version string
+	Atlas   AtlasExec
 }
 
 // Atlas action interface.
@@ -486,7 +483,7 @@ func (a *Actions) GetRunContext(ctx context.Context, tc *TriggerContext) *atlase
 func (a *Actions) DeployRunContext() *atlasexec.DeployRunContext {
 	return &atlasexec.DeployRunContext{
 		TriggerType:    a.GetType(),
-		TriggerVersion: Version,
+		TriggerVersion: a.Version,
 	}
 }
 

--- a/atlasaction/action_test.go
+++ b/atlasaction/action_test.go
@@ -1950,7 +1950,6 @@ func TestMigrateApplyCloud(t *testing.T) {
 		}
 	}
 	t.Run("basic", func(t *testing.T) {
-		Version = "v1.2.3"
 		var payloads []string
 		srv := httptest.NewServer(handler(&payloads))
 		t.Cleanup(srv.Close)
@@ -1963,7 +1962,7 @@ func TestMigrateApplyCloud(t *testing.T) {
 		// This isn't simulating a user input but is a workaround for testing Cloud API calls.
 		cfgURL := generateHCL(t, srv.URL, "token")
 		tt.setInput("config", cfgURL)
-		err := (&Actions{Action: tt.act, Atlas: tt.cli}).MigrateApply(context.Background())
+		err := (&Actions{Action: tt.act, Atlas: tt.cli, Version: "v1.2.3"}).MigrateApply(context.Background())
 		require.NoError(t, err)
 
 		require.Len(t, payloads, 3)

--- a/cmd/atlas-action/main.go
+++ b/cmd/atlas-action/main.go
@@ -26,6 +26,15 @@ const (
 	CmdSchemaTest = "schema/test"
 )
 
+var (
+	// version holds atlas-action version. When built with cloud packages should be set by build flag, e.g.
+	// "-X 'main.version=v0.1.2'"
+	version string
+	// commit holds the git commit hash. When built with cloud packages should be set by build flag, e.g.
+	// "-X 'main.commit=abcdef1234'"
+	commit string = "dev"
+)
+
 func main() {
 	action, err := newAction()
 	if err != nil {
@@ -41,8 +50,9 @@ func main() {
 		kong.BindTo(context.Background(), (*context.Context)(nil)),
 	)
 	if err := cli.Run(&atlasaction.Actions{
-		Action: action,
-		Atlas:  atlas,
+		Action:  action,
+		Version: version,
+		Atlas:   atlas,
 	}); err != nil {
 		if uerr := errors.Unwrap(err); uerr != nil {
 			err = uerr
@@ -56,7 +66,7 @@ type VersionFlag bool
 
 // BeforeReset writes the version variable and terminates with a 0 exit status.
 func (v VersionFlag) BeforeReset(app *kong.Kong) error {
-	_, err := fmt.Fprintln(app.Stdout, atlasaction.Version)
+	_, err := fmt.Fprintf(app.Stdout, "%s-%s\n", version, commit)
 	app.Exit(0)
 	return err
 }


### PR DESCRIPTION
Changes:
- Added Commit ID info into atlas-actions' version
- Build when tags pushed.
- By default, use tag or branch name for the binary (No more default to `v1`). It mean, push to the master branch will upload `atlas-action-master` instead of `atlas-action-v1`. In the following PR, I'll update the logic of shim to download the `-master` version for `@master` tag.