### PR TITLE
schema/push: fixed repo name input

### DIFF
--- a/atlasaction/action.go
+++ b/atlasaction/action.go
@@ -444,7 +444,7 @@ func (a *Actions) SchemaPush(ctx context.Context) error {
 		return err
 	}
 	params := &atlasexec.SchemaPushParams{
-		Repo:        a.GetAtlasURLInput("schema-name"),
+		Name:        a.GetInput("schema-name"),
 		Description: a.GetInput("description"),
 		Version:     a.GetInput("version"),
 		DevURL:      a.GetInput("dev-url"),

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23
 
 require (
 	ariga.io/atlas v0.21.2-0.20240418081819-02b3f6239b04
-	ariga.io/atlas-go-sdk v0.6.0
+	ariga.io/atlas-go-sdk v0.6.2
 	github.com/alecthomas/kong v0.8.0
 	github.com/mattn/go-sqlite3 v1.14.17
 	github.com/mitchellh/mapstructure v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 ariga.io/atlas v0.21.2-0.20240418081819-02b3f6239b04 h1:YF3qiqtnhn+y4tfhZKTfZKfizpjqHYt7rWPUb+eA4ZA=
 ariga.io/atlas v0.21.2-0.20240418081819-02b3f6239b04/go.mod h1:VPlcXdd4w2KqKnH54yEZcry79UAhpaWaxEsmn5JRNoE=
-ariga.io/atlas-go-sdk v0.6.0 h1:+i4+M1Lug5BwaLWf62CP+j5S/vrlTJgQKnY6gKHNDco=
-ariga.io/atlas-go-sdk v0.6.0/go.mod h1:9Q+/04PVyJHUse1lEE9Kp6E18xj/6mIzaUTcWYSjSnQ=
+ariga.io/atlas-go-sdk v0.6.2 h1:u7IAH6FqXRLpbW67Zw3jTy3Mz7lCB/rhbdPCorFhYTY=
+ariga.io/atlas-go-sdk v0.6.2/go.mod h1:9Q+/04PVyJHUse1lEE9Kp6E18xj/6mIzaUTcWYSjSnQ=
 github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
 github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=


### PR DESCRIPTION
Fix bug caused by https://github.com/ariga/atlas-action/pull/238, I was miss understand the schema's name and `Repo` with `atlas://` as its prefix.