### PR TITLE
atlasaction: support output for circle-ci

### DIFF
--- a/atlasaction/action_test.go
+++ b/atlasaction/action_test.go
@@ -2388,8 +2388,13 @@ func atlasAction(ts *testscript.TestScript, neg bool, args []string) {
 	ts.Check(err)
 	act.Atlas = client.AtlasExec
 	act.Version = "testscript"
+	action := args[0]
+	ts.Setenv("ATLAS_ACTION_COMMAND", action)
+	ts.Defer(func() {
+		ts.Setenv("ATLAS_ACTION_COMMAND", "")
+	})
 	// Run the action!
-	switch err := act.Run(context.Background(), args[0]); {
+	switch err := act.Run(context.Background(), action); {
 	case !neg:
 		ts.Check(err)
 	case err == nil:

--- a/atlasaction/circleci_action.go
+++ b/atlasaction/circleci_action.go
@@ -46,7 +46,25 @@ func (a *circleCIOrb) GetInput(name string) string {
 
 // SetOutput implements the Action interface.
 func (a *circleCIOrb) SetOutput(name, value string) {
-	// unsupported
+	if bashEnv := a.getenv("BASH_ENV"); bashEnv != "" {
+		// Write the output to a file.
+		f, err := os.OpenFile(bashEnv, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		if err != nil {
+			a.Fatalf("failed to open file %s: %v", bashEnv, err)
+		}
+		defer f.Close()
+		var (
+			envReplacer = strings.NewReplacer(" ", "_", "-", "_", "/", "_")
+			cmdName     = a.getenv("ATLAS_ACTION_COMMAND")
+			envName     = strings.ToUpper(envReplacer.Replace(fmt.Sprintf(
+				"ATLAS_OUTPUT_%s_%s", cmdName, name)))
+		)
+		_, err = fmt.Fprintf(f, "export %s=%q\n", envName, value)
+		if err != nil {
+			a.Fatalf("failed to write to file %s: %v", bashEnv, err)
+		}
+		return
+	}
 }
 
 // GetTriggerContext implements the Action interface.

--- a/atlasaction/circleci_action_test.go
+++ b/atlasaction/circleci_action_test.go
@@ -8,9 +8,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"ariga.io/atlas-action/atlasaction"
+	"ariga.io/atlas-go-sdk/atlasexec"
+	"github.com/rogpeppe/go-internal/testscript"
 	"github.com/stretchr/testify/require"
 )
 
@@ -52,4 +55,52 @@ func Test_circleCIOrb_GetTriggerContext(t *testing.T) {
 		URL:    "https://api.github.com/repos/ariga/atlas-orb/pulls/9",
 		Commit: "1234567890",
 	}, ctx.PullRequest)
+}
+
+func TestCircleCI(t *testing.T) {
+	var (
+		actions = "actions"
+		output  = filepath.Join(actions, "output.txt")
+	)
+	testscript.Run(t, testscript.Params{
+		Dir: filepath.Join("testdata", "circleci"),
+		Setup: func(e *testscript.Env) (err error) {
+			dir := filepath.Join(e.WorkDir, actions)
+			if err := os.Mkdir(dir, 0700); err != nil {
+				return err
+			}
+			e.Setenv("CIRCLECI", "true")
+			e.Setenv("CIRCLE_PROJECT_REPONAME", "atlas-orb")
+			e.Setenv("CIRCLE_SHA1", "1234567890")
+			e.Setenv("BASH_ENV", filepath.Join(dir, "output.txt"))
+			c, err := atlasexec.NewClient(e.WorkDir, "atlas")
+			if err != nil {
+				return err
+			}
+			// Create a new actions for each test.
+			e.Values[atlasKey{}] = &atlasClient{c}
+			return nil
+		},
+		Cmds: map[string]func(ts *testscript.TestScript, neg bool, args []string){
+			"atlas-action": atlasAction,
+			"mock-atlas":   mockAtlasOutput,
+			"output": func(ts *testscript.TestScript, neg bool, args []string) {
+				if len(args) == 0 {
+					_, err := os.Stat(ts.MkAbs(output))
+					if neg {
+						if !os.IsNotExist(err) {
+							ts.Fatalf("expected no output, but got some")
+						}
+						return
+					}
+					if err != nil {
+						ts.Fatalf("expected output, but got none")
+						return
+					}
+					return
+				}
+				cmpFiles(ts, neg, args[0], output)
+			},
+		},
+	})
 }

--- a/atlasaction/testdata/circleci/migrate-lint.txtar
+++ b/atlasaction/testdata/circleci/migrate-lint.txtar
@@ -1,0 +1,26 @@
+# Mock the atlas command outputs
+mock-atlas $WORK/migrate-lint
+# Setup the action input variables
+env INPUT_CONFIG=file://testdata/config/atlas.hcl
+env INPUT_ENV=test
+env INPUT_DIR_NAME=pupisu
+env INPUT_TAG=staging
+env INPUT_VARS='{"var1":"value1","var2":"value2"}'
+env INPUT_DIR=file://testdata/migrations
+env INPUT_DEV_URL=sqlite://file?mode=memory
+env INPUT_RUN=example
+
+# The action's output should append the existing outputs
+cp output-pre.txt actions/output.txt
+atlas-action migrate/lint
+output output.txt
+
+-- migrate-lint/1/args --
+migrate lint -w --context {"repo":"atlas-orb","path":"file://testdata/migrations","commit":"1234567890"} --env test --config file://testdata/config/atlas.hcl --dev-url sqlite://file?mode=memory --dir file://testdata/migrations --base atlas://pupisu?tag=staging --var var1=value1 --var var2=value2 --format {{ json . }}
+-- migrate-lint/1/stdout --
+{"URL":"https://migration-lint-report-url"}
+-- output-pre.txt --
+export FOO=bar
+-- output.txt --
+export FOO=bar
+export ATLAS_OUTPUT_MIGRATE_LINT_REPORT_URL="https://migration-lint-report-url"


### PR DESCRIPTION
Any action that supports output will add `ATLAS_OUTPUT_<ACTION_NAME>_<OUTPUT_NAME>` to `$BASH_ENV` file.

for example the `migrate/lint` action has `report-url` output that will add `ATLAS_OUTPUT_MIGRATE_LINT_REPORT_URL`. `/`, `-`, and ` ` (space) will be replaced with `_`, and all characters will be in upper case.

More detail: https://circleci.com/docs/env-vars/#parameters-and-bash-environment

> Another possible method to interpolate values into your configuration is to use a run step to export environment variables to BASH_ENV, as shown below.
> In every step, CircleCI uses bash to source BASH_ENV. This means that BASH_ENV is automatically loaded and run, allowing you to use interpolation and share environment variables across run steps.

