### PR TITLE
dont pass cloud-token twice in schema monitor action

### DIFF
--- a/.github/workflows/ci-go.yaml
+++ b/.github/workflows/ci-go.yaml
@@ -436,16 +436,7 @@ jobs:
           SELECT id, email FROM users;
           EOF
           echo "Table and view created!"
-
-      - name: Verify Table and View
-        run: |
-          echo "Verifying table and view..."
-          mysql -h 127.0.0.1 -u root --password=pass dev -e "SHOW TABLES;"
-          mysql -h 127.0.0.1 -u root --password=pass dev -e "SELECT * FROM user_emails;"
-
       - uses: ariga/setup-atlas@v0
-        with:
-          cloud-token: ${{ secrets.ATLAS_TOKEN }}
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:

--- a/.github/workflows/ci-go.yaml
+++ b/.github/workflows/ci-go.yaml
@@ -421,6 +421,28 @@ jobs:
     env:
       ATLAS_ACTION_LOCAL: 1
     steps:
+      # views are logged in only feature in atlas
+      - name: Create Table and View
+        run: |
+          echo "Creating table and view..."
+          mysql -h 127.0.0.1 -u root --password=pass dev <<EOF
+          CREATE TABLE users (
+              id INT AUTO_INCREMENT PRIMARY KEY,
+              name VARCHAR(255) NOT NULL,
+              email VARCHAR(255) NOT NULL
+          );
+
+          CREATE VIEW user_emails AS
+          SELECT id, email FROM users;
+          EOF
+          echo "Table and view created!"
+
+      - name: Verify Table and View
+        run: |
+          echo "Verifying table and view..."
+          mysql -h 127.0.0.1 -u root --password=pass dev -e "SHOW TABLES;"
+          mysql -h 127.0.0.1 -u root --password=pass dev -e "SELECT * FROM user_emails;"
+
       - uses: ariga/setup-atlas@v0
         with:
           cloud-token: ${{ secrets.ATLAS_TOKEN }}

--- a/atlasaction/action.go
+++ b/atlasaction/action.go
@@ -81,6 +81,7 @@ type (
 
 	// AtlasExec is the interface for the atlas exec client.
 	AtlasExec interface {
+		Login(ctx context.Context, params *atlasexec.LoginParams) error
 		// MigrateStatus runs the `migrate status` command.
 		MigrateStatus(context.Context, *atlasexec.MigrateStatusParams) (*atlasexec.MigrateStatus, error)
 		// MigrateApplySlice runs the `migrate apply` command and returns the successful runs.
@@ -839,6 +840,11 @@ func (a *Actions) MonitorSchema(ctx context.Context) error {
 			Exclude: a.GetArrayInput("exclude"),
 		}
 	)
+	if err = a.Atlas.Login(ctx, &atlasexec.LoginParams{
+		Token: a.GetInput("cloud-token"),
+	}); err != nil {
+		return fmt.Errorf("failed to login to Atlas Cloud: %w", err)
+	}
 	res, err := a.Atlas.SchemaInspect(ctx, &atlasexec.SchemaInspectParams{
 		URL:     db.String(),
 		Schema:  id.Schemas,

--- a/atlasaction/action_test.go
+++ b/atlasaction/action_test.go
@@ -279,6 +279,7 @@ func TestMigrateDown(t *testing.T) {
 }
 
 type mockAtlas struct {
+	login             func(context.Context, *atlasexec.LoginParams) error
 	migrateDown       func(context.Context, *atlasexec.MigrateDownParams) (*atlasexec.MigrateDown, error)
 	schemaInspect     func(context.Context, *atlasexec.SchemaInspectParams) (string, error)
 	schemaPush        func(context.Context, *atlasexec.SchemaPushParams) (*atlasexec.SchemaPush, error)
@@ -289,6 +290,11 @@ type mockAtlas struct {
 }
 
 var _ atlasaction.AtlasExec = (*mockAtlas)(nil)
+
+// Login implements AtlasExec.
+func (m *mockAtlas) Login(ctx context.Context, params *atlasexec.LoginParams) error {
+	return m.login(ctx, params)
+}
 
 // MigrateStatus implements AtlasExec.
 func (m *mockAtlas) MigrateStatus(context.Context, *atlasexec.MigrateStatusParams) (*atlasexec.MigrateStatus, error) {
@@ -634,6 +640,9 @@ func TestMonitorSchema(t *testing.T) {
 					logger: slog.New(slog.NewTextHandler(out, nil)),
 				}
 				cli = &mockAtlas{
+					login: func(ctx context.Context, params *atlasexec.LoginParams) error {
+						return nil
+					},
 					schemaInspect: func(_ context.Context, p *atlasexec.SchemaInspectParams) (string, error) {
 						return fmt.Sprintf("# %s\n%s", tt.newHash, tt.hcl), nil
 					},


### PR DESCRIPTION
this PR moves the login logic from atlas step to monitor step, thus we dont pass the `cloud-token` twice in the yaml

![image](https://github.com/user-attachments/assets/820ab5f9-2c38-4f21-9266-82ba3ea16eba)
