### PR TITLE
remove require log in from action lint readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To learn more about the recommended way to build workflows, read our guide on
 |-------------------------------------------------------------------------------|-------------------------------------------------------------------------------------|
 | [ariga/setup-atlas](#arigasetup-atlas)                                        | Setup the Atlas CLI and optionally login to Atlas Cloud                             |
 | [ariga/atlas-action/migrate/push](#arigaatlas-actionmigratepush)              | Push migrations to [Atlas Registry](https://atlasgo.io/registry)                    |
-| [ariga/atlas-action/migrate/lint](#arigaatlas-actionmigratelint)              | Lint migrations (required `atlas login` )                                           |
+| [ariga/atlas-action/migrate/lint](#arigaatlas-actionmigratelint)              | Lint migrations                                                                     |
 | [ariga/atlas-action/migrate/apply](#arigaatlas-actionmigrateapply)            | Apply migrations to a database                                                      |
 | [ariga/atlas-action/migrate/down](#arigaatlas-actionmigratedown)              | Revert migrations to a database                                                     |
 | [ariga/atlas-action/migrate/test](#arigaatlas-actionmigratetest)              | Test migrations on a database                                                       |
@@ -212,7 +212,7 @@ All inputs are optional as they may be specified in the Atlas configuration file
 
 * `url` - The URL of the migration directory in Atlas Cloud, containing an ERD visualization of the schema.
 
-### `ariga/atlas-action/migrate/lint` (Required `atlas login`)
+### `ariga/atlas-action/migrate/lint`
 
 Lint migration changes with Atlas
 


### PR DESCRIPTION
first, it is not true that `lint action` requires logging in, and second it breaks the makrdown linkage (see video)


https://github.com/user-attachments/assets/486673c8-2b86-4580-b71f-3630784b994f

