### PR TITLE
chore: add `tx-mode` input for migration/schema apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ All inputs are optional as they may be specified in the Atlas configuration file
    For example: `'{"var1": "value1", "var2": "value2"}'`.
 * `working-directory` - The working directory to run from.  Defaults to project root.
 * `allow-dirty` - Allow applying migration on a non-clean database. Defaults to false.
+* `tx-mode` - The transaction mode for migrations. It can be either `file`, `all`, or `none`. The default is `file`.
 
 #### Outputs
 
@@ -364,6 +365,7 @@ Apply a declarative migrations to a database.
 * `vars` - Stringify JSON object containing variables to be used inside the Atlas configuration file.
   For example: `'{"var1": "value1", "var2": "value2"}'`.
 * `working-directory` - The working directory to run from.  Defaults to project root.
+* `tx-mode` - The transaction mode for migrations. It can be either `file`, `all`, or `none`. The default is `file`.
 
 #### Outputs
 

--- a/migrate/apply/action.yml
+++ b/migrate/apply/action.yml
@@ -41,6 +41,10 @@ inputs:
   allow-dirty:
     description: Allow start working on a non-clean database.
     required: false
+  tx-mode:
+    description: |
+      Transaction mode to use. Either "file", "all", or "none". Default is "file".
+    required: false
 outputs:
   current:
     description: The current version of the database. (before applying migrations)

--- a/schema/apply/action.yml
+++ b/schema/apply/action.yml
@@ -49,6 +49,10 @@ inputs:
     description: Automatically approve and apply changes. Either "true" or "false".
     required: false
     default: "false"
+  tx-mode:
+    description: |
+      Transaction mode to use. Either "file", "all", or "none". Default is "file".
+    required: false
 outputs:
   error:
     description: The error message if the action fails.


### PR DESCRIPTION
This pull request includes changes to add a new `tx-mode` input parameter for specifying the transaction mode for migrations. The changes are made across multiple files to ensure consistency and proper documentation.

### Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R263): Added the `tx-mode` parameter description under the sections for inputs in the migration configuration. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R263) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R368)

### Configuration updates:

* [`migrate/apply/action.yml`](diffhunk://#diff-f0659287a2a21eb4b307db47bfa1e9f3f93cbdbb1dcd4c57087940843d14d861R44-R47): Introduced the `tx-mode` parameter with a description and default value.
* [`schema/apply/action.yml`](diffhunk://#diff-77f4937173e7eea7a278bfea3273901d38d1b44ff7670486c1a59c31384b84bfR52-R55): Added the `tx-mode` parameter with detailed description and default value.