### PR TITLE
atlasaction: use `merge` instead of `rebase` in migrate/autorebase

### DIFF
--- a/.github/workflows/ci-go.yaml
+++ b/.github/workflows/ci-go.yaml
@@ -376,7 +376,7 @@ jobs:
           - directory: multiple-envs
             plan: "file://20240910173744.plan.hcl"
           - directory: legacy
-            atlas: 'v0.27.0'
+            atlas: 'v0.28.0'
             auto-approve: "true"
     steps:
       - uses: ariga/setup-atlas@v0

--- a/atlasaction/action_test.go
+++ b/atlasaction/action_test.go
@@ -635,8 +635,8 @@ func TestMigrateAutorebase(t *testing.T) {
 				// Dummy command to avoid errors
 				cmd := exec.CommandContext(ctx, "echo")
 				switch {
-				// Simulate a conflict when running `git rebase origin/rebase-branch`
-				case len(args) > 1 && args[0] == "rebase" && args[1] == "origin/rebase-branch":
+				// Simulate a conflict when running `git merge --no-ff origin/rebase-branch`
+				case len(args) > 1 && args[0] == "merge" && args[1] == "origin/rebase-branch":
 					cmd.Err = errors.New("CONFLICT")
 				// Simulate result when running: git show
 				case len(args) > 1 && args[0] == "show":
@@ -683,17 +683,16 @@ func TestMigrateAutorebase(t *testing.T) {
 		require.Len(t, rebasedFiles, 1)
 		require.Equal(t, "20250309093464_rebase.sql", rebasedFiles[0])
 		// Check that the correct git commands were executed
-		require.Len(t, mockExec.ran, 10)
+		require.Len(t, mockExec.ran, 9)
 		require.Equal(t, []string{"fetch", "origin", "rebase-branch"}, mockExec.ran[0].args)
 		require.Equal(t, []string{"checkout", "my-branch"}, mockExec.ran[1].args)
 		require.Equal(t, []string{"show", "origin/rebase-branch:testdata/need_rebase/atlas.sum"}, mockExec.ran[2].args)
 		require.Equal(t, []string{"show", "origin/my-branch:testdata/need_rebase/atlas.sum"}, mockExec.ran[3].args)
-		require.Equal(t, []string{"rebase", "origin/rebase-branch"}, mockExec.ran[4].args)
+		require.Equal(t, []string{"merge", "--no-ff", "origin/rebase-branch"}, mockExec.ran[4].args)
 		require.Equal(t, []string{"diff", "--name-only", "--diff-filter=U"}, mockExec.ran[5].args)
 		require.Equal(t, []string{"add", "testdata/need_rebase"}, mockExec.ran[6].args)
 		require.Equal(t, []string{"commit", "-m", "Rebase migrations in testdata/need_rebase"}, mockExec.ran[7].args)
-		require.Equal(t, []string{"rebase", "--continue"}, mockExec.ran[8].args)
-		require.Equal(t, []string{"push", "--force-with-lease", "origin", "my-branch"}, mockExec.ran[9].args)
+		require.Equal(t, []string{"push", "--force-with-lease", "origin", "my-branch"}, mockExec.ran[8].args)
 	})
 	t.Run("conflict, but not in atlas.sum", func(t *testing.T) {
 		mockExec := &MockCmdExecutor{
@@ -701,8 +700,8 @@ func TestMigrateAutorebase(t *testing.T) {
 				// Dummy command to avoid errors
 				cmd := exec.CommandContext(ctx, "echo")
 				switch {
-				// Simulate a conflict when running `git rebase origin/rebase-branch`
-				case len(args) > 1 && args[0] == "rebase" && args[1] == "origin/rebase-branch":
+				// Simulate a conflict when running `git merge --no-ff origin/rebase-branch`
+				case len(args) > 1 && args[0] == "merge" && args[1] == "origin/rebase-branch":
 					cmd.Err = errors.New("CONFLICT")
 				// Simulate result when running: git show
 				case len(args) > 1 && args[0] == "show":
@@ -749,7 +748,7 @@ func TestMigrateAutorebase(t *testing.T) {
 		require.Equal(t, []string{"checkout", "my-branch"}, mockExec.ran[1].args)
 		require.Equal(t, []string{"show", "origin/rebase-branch:testdata/need_rebase/atlas.sum"}, mockExec.ran[2].args)
 		require.Equal(t, []string{"show", "origin/my-branch:testdata/need_rebase/atlas.sum"}, mockExec.ran[3].args)
-		require.Equal(t, []string{"rebase", "origin/rebase-branch"}, mockExec.ran[4].args)
+		require.Equal(t, []string{"merge", "--no-ff", "origin/rebase-branch"}, mockExec.ran[4].args)
 		require.Equal(t, []string{"diff", "--name-only", "--diff-filter=U"}, mockExec.ran[5].args)
 	})
 

--- a/atlasaction/action_test.go
+++ b/atlasaction/action_test.go
@@ -636,8 +636,8 @@ func TestMigrateAutorebase(t *testing.T) {
 				cmd := exec.CommandContext(ctx, "echo")
 				switch {
 				// Simulate a conflict when running `git merge --no-ff origin/rebase-branch`
-				case len(args) > 1 && args[0] == "merge" && args[1] == "origin/rebase-branch":
-					cmd.Err = errors.New("CONFLICT")
+				case len(args) > 2 && args[0] == "merge" && args[2] == "origin/rebase-branch":
+					cmd = exec.CommandContext(ctx, "echo", "CONFLICT")
 				// Simulate result when running: git show
 				case len(args) > 1 && args[0] == "show":
 					var res string
@@ -692,7 +692,7 @@ func TestMigrateAutorebase(t *testing.T) {
 		require.Equal(t, []string{"diff", "--name-only", "--diff-filter=U"}, mockExec.ran[5].args)
 		require.Equal(t, []string{"add", "testdata/need_rebase"}, mockExec.ran[6].args)
 		require.Equal(t, []string{"commit", "-m", "Rebase migrations in testdata/need_rebase"}, mockExec.ran[7].args)
-		require.Equal(t, []string{"push", "--force-with-lease", "origin", "my-branch"}, mockExec.ran[8].args)
+		require.Equal(t, []string{"push", "origin", "my-branch"}, mockExec.ran[8].args)
 	})
 	t.Run("conflict, but not in atlas.sum", func(t *testing.T) {
 		mockExec := &MockCmdExecutor{
@@ -701,8 +701,8 @@ func TestMigrateAutorebase(t *testing.T) {
 				cmd := exec.CommandContext(ctx, "echo")
 				switch {
 				// Simulate a conflict when running `git merge --no-ff origin/rebase-branch`
-				case len(args) > 1 && args[0] == "merge" && args[1] == "origin/rebase-branch":
-					cmd.Err = errors.New("CONFLICT")
+				case len(args) > 2 && args[0] == "merge" && args[2] == "origin/rebase-branch":
+					cmd = exec.CommandContext(ctx, "echo", "CONFLICT")
 				// Simulate result when running: git show
 				case len(args) > 1 && args[0] == "show":
 					var res string


### PR DESCRIPTION
Now user can `git pull origin` the changes created by the action without facing conflicts:

<img width="994" alt="Screenshot 2025-03-16 at 14 02 08" src="https://github.com/user-attachments/assets/748a82b6-0184-4bd7-80fc-3ccb173d9383" />

example [run](https://github.com/ariga/atlas-action/pull/352)