### PR TITLE
.github/workflows: fix typo for legacy version

### DIFF
--- a/.github/workflows/ci-go.yaml
+++ b/.github/workflows/ci-go.yaml
@@ -514,7 +514,7 @@ jobs:
       - uses: ariga/setup-atlas@2f3c785c89a15e1c0d07bcae3900fb5feb969eea # v0
         with:
           cloud-token: ${{ secrets.ATLAS_TOKEN }}
-          version: ${{ matrix.test.atlas }}
+          version: ${{ matrix.test.version }}
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4
         with:

--- a/atlasaction/action_test.go
+++ b/atlasaction/action_test.go
@@ -367,8 +367,18 @@ func TestSchemaApplyWithApproval(t *testing.T) {
 		tt := setup(t)
 		tt.setInput("lint-review", "ALWAYS")
 		tt.setInput("to", "atlas://example")
-		tt.cloud.AddPlan("pr-0-r1cgcsfo", "example", "PENDING", "R1cGcSfo1oWYK4dz+7WvgCtE/QppFo9lKFEqEDzoS4o=", "IILaNACeZkEfb09c0HSdi5lPLLrWf4PAo/KtDcMUxsk=")
-		tt.cloud.AddPlan("pr-0-r1cgcsfo-2", "example", "PENDING", "R1cGcSfo1oWYK4dz+7WvgCtE/QppFo9lKFEqEDzoS4o=", "IILaNACeZkEfb09c0HSdi5lPLLrWf4PAo/KtDcMUxsk=")
+		const migration = `create table "t1" ("id" int null);`
+		tt.cloud.AddPlan("pr-0-r1cgcsfo", "example", "PENDING", "R1cGcSfo1oWYK4dz+7WvgCtE/QppFo9lKFEqEDzoS4o=", "IILaNACeZkEfb09c0HSdi5lPLLrWf4PAo/KtDcMUxsk=", migration)
+		tt.cloud.AddPlan("pr-0-r1cgcsfo-2", "example", "PENDING", "R1cGcSfo1oWYK4dz+7WvgCtE/QppFo9lKFEqEDzoS4o=", "IILaNACeZkEfb09c0HSdi5lPLLrWf4PAo/KtDcMUxsk=", migration)
+		require.NoError(t, tt.newActs(t).SchemaApply(context.Background()))
+	})
+
+	t.Run("generating an approval plan when having > 1 pending plan with different migration content", func(t *testing.T) {
+		tt := setup(t)
+		tt.setInput("lint-review", "ALWAYS")
+		tt.setInput("to", "atlas://example")
+		tt.cloud.AddPlan("pr-0-r1cgcsfo", "example", "PENDING", "R1cGcSfo1oWYK4dz+7WvgCtE/QppFo9lKFEqEDzoS4o=", "IILaNACeZkEfb09c0HSdi5lPLLrWf4PAo/KtDcMUxsk=", `create table "t1" ("id" int null);`)
+		tt.cloud.AddPlan("pr-0-r1cgcsfo-2", "example", "PENDING", "R1cGcSfo1oWYK4dz+7WvgCtE/QppFo9lKFEqEDzoS4o=", "IILaNACeZkEfb09c0HSdi5lPLLrWf4PAo/KtDcMUxsk=", `create table "t1" ("id" int not null);`)
 		require.ErrorContains(t, tt.newActs(t).SchemaApply(context.Background()), "multiple pre-planned migrations were found in the registry for this schema transition")
 		require.ErrorContains(t, tt.newActs(t).SchemaApply(context.Background()), "atlas://repo/schema/example/plans/pr-0-r1cgcsfo")
 	})
@@ -456,6 +466,7 @@ type (
 		Status     string `json:"status"`
 		FromHash   string `json:"fromHash"`
 		ToHash     string `json:"toHash"`
+		Migration  string `json:"migration"`
 		Link       string `json:"link"`
 		URL        string `json:"url"`
 	}
@@ -479,12 +490,16 @@ func (m *mockAtlasCloud) AddSchema(name, schema string) {
 	}
 }
 
-func (m *mockAtlasCloud) AddPlan(name, schemaSlug, status, fromHash, toHash string) {
+func (m *mockAtlasCloud) AddPlan(name, schemaSlug, status, fromHash, toHash string, migration ...string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.planCount++
 	link := fmt.Sprintf("https://a8m.atlasgo.cloud/schemas/%d/plans/%d", m.schemaCount, m.planCount)
 	url := fmt.Sprintf("atlas://repo/schema/%s/plans/%s", schemaSlug, name)
+	content := ""
+	if len(migration) > 0 {
+		content = migration[0]
+	}
 	plan := Plan{
 		ID:         m.planCount,
 		Name:       name,
@@ -492,6 +507,7 @@ func (m *mockAtlasCloud) AddPlan(name, schemaSlug, status, fromHash, toHash stri
 		Status:     status,
 		FromHash:   fromHash,
 		ToHash:     toHash,
+		Migration:  content,
 		Link:       link,
 		URL:        url,
 	}

--- a/atlasaction/action_test.go
+++ b/atlasaction/action_test.go
@@ -368,8 +368,8 @@ func TestSchemaApplyWithApproval(t *testing.T) {
 		tt.setInput("lint-review", "ALWAYS")
 		tt.setInput("to", "atlas://example")
 		const migration = `create table "t1" ("id" int null);`
-		tt.cloud.AddPlan("pr-0-r1cgcsfo", "example", "PENDING", "R1cGcSfo1oWYK4dz+7WvgCtE/QppFo9lKFEqEDzoS4o=", "IILaNACeZkEfb09c0HSdi5lPLLrWf4PAo/KtDcMUxsk=", migration)
-		tt.cloud.AddPlan("pr-0-r1cgcsfo-2", "example", "PENDING", "R1cGcSfo1oWYK4dz+7WvgCtE/QppFo9lKFEqEDzoS4o=", "IILaNACeZkEfb09c0HSdi5lPLLrWf4PAo/KtDcMUxsk=", migration)
+		tt.cloud.AddPlanWithMigration("pr-0-r1cgcsfo", "example", "PENDING", "R1cGcSfo1oWYK4dz+7WvgCtE/QppFo9lKFEqEDzoS4o=", "IILaNACeZkEfb09c0HSdi5lPLLrWf4PAo/KtDcMUxsk=", migration)
+		tt.cloud.AddPlanWithMigration("pr-0-r1cgcsfo-2", "example", "PENDING", "R1cGcSfo1oWYK4dz+7WvgCtE/QppFo9lKFEqEDzoS4o=", "IILaNACeZkEfb09c0HSdi5lPLLrWf4PAo/KtDcMUxsk=", migration)
 		require.NoError(t, tt.newActs(t).SchemaApply(context.Background()))
 	})
 
@@ -377,8 +377,8 @@ func TestSchemaApplyWithApproval(t *testing.T) {
 		tt := setup(t)
 		tt.setInput("lint-review", "ALWAYS")
 		tt.setInput("to", "atlas://example")
-		tt.cloud.AddPlan("pr-0-r1cgcsfo", "example", "PENDING", "R1cGcSfo1oWYK4dz+7WvgCtE/QppFo9lKFEqEDzoS4o=", "IILaNACeZkEfb09c0HSdi5lPLLrWf4PAo/KtDcMUxsk=", `create table "t1" ("id" int null);`)
-		tt.cloud.AddPlan("pr-0-r1cgcsfo-2", "example", "PENDING", "R1cGcSfo1oWYK4dz+7WvgCtE/QppFo9lKFEqEDzoS4o=", "IILaNACeZkEfb09c0HSdi5lPLLrWf4PAo/KtDcMUxsk=", `create table "t1" ("id" int not null);`)
+		tt.cloud.AddPlanWithMigration("pr-0-r1cgcsfo", "example", "PENDING", "R1cGcSfo1oWYK4dz+7WvgCtE/QppFo9lKFEqEDzoS4o=", "IILaNACeZkEfb09c0HSdi5lPLLrWf4PAo/KtDcMUxsk=", `create table "t1" ("id" int null);`)
+		tt.cloud.AddPlanWithMigration("pr-0-r1cgcsfo-2", "example", "PENDING", "R1cGcSfo1oWYK4dz+7WvgCtE/QppFo9lKFEqEDzoS4o=", "IILaNACeZkEfb09c0HSdi5lPLLrWf4PAo/KtDcMUxsk=", `create table "t1" ("id" int not null);`)
 		require.ErrorContains(t, tt.newActs(t).SchemaApply(context.Background()), "multiple pre-planned migrations were found in the registry for this schema transition")
 		require.ErrorContains(t, tt.newActs(t).SchemaApply(context.Background()), "atlas://repo/schema/example/plans/pr-0-r1cgcsfo")
 	})
@@ -490,16 +490,16 @@ func (m *mockAtlasCloud) AddSchema(name, schema string) {
 	}
 }
 
-func (m *mockAtlasCloud) AddPlan(name, schemaSlug, status, fromHash, toHash string, migration ...string) {
+func (m *mockAtlasCloud) AddPlan(name, schemaSlug, status, fromHash, toHash string) {
+	m.AddPlanWithMigration(name, schemaSlug, status, fromHash, toHash, "")
+}
+
+func (m *mockAtlasCloud) AddPlanWithMigration(name, schemaSlug, status, fromHash, toHash, migration string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.planCount++
 	link := fmt.Sprintf("https://a8m.atlasgo.cloud/schemas/%d/plans/%d", m.schemaCount, m.planCount)
 	url := fmt.Sprintf("atlas://repo/schema/%s/plans/%s", schemaSlug, name)
-	content := ""
-	if len(migration) > 0 {
-		content = migration[0]
-	}
 	plan := Plan{
 		ID:         m.planCount,
 		Name:       name,
@@ -507,7 +507,7 @@ func (m *mockAtlasCloud) AddPlan(name, schemaSlug, status, fromHash, toHash stri
 		Status:     status,
 		FromHash:   fromHash,
 		ToHash:     toHash,
-		Migration:  content,
+		Migration:  migration,
 		Link:       link,
 		URL:        url,
 	}


### PR DESCRIPTION
<img width="726" height="814" alt="image" src="https://github.com/user-attachments/assets/0f95d9b7-ff98-40a9-a779-c9abcfe3ebe0" />

the matrix var is version, not atlas