### PR TITLE
atlasaction/templates: fix the generated CircleCI orb

### DIFF
--- a/atlasaction/templates/orb-yml.tmpl
+++ b/atlasaction/templates/orb-yml.tmpl
@@ -9,10 +9,13 @@ parameters:
     type: {{ $input | orbtype }}
     default: {{ if $input.Default }}{{ if eq $input.Type "boolean" }}{{ $input.Default }}{{ else }}'{{ $input.Default }}'{{ end }}{{ else }}{{ if eq $name "working-directory" }}'.'{{ else }}{{ if eq $input.Type "boolean" }}false{{ else }}''{{ end }}{{ end }}{{ end }}
     description: |
-      {{ $input.Description | trimnl }}
+      {{ $input.Description | trimnl | replace "\n" "\n      " }}
 {{- if $input.Options }}
 
     enum:
+      {{- if eq $input.Default "" }}
+      - ''
+      {{- end }}
       {{- range $v := $input.Options }}
       - {{ $v }}
       {{- end }}


### PR DESCRIPTION
Every generated orb file with a multi-line input description was invalid YAML: the continuation lines sat at column 0, which closes the block scalar they belong to. 20 of the 24 files did not parse. Indent them with the block.

CircleCI also rejects an enum parameter whose default is not one of its values, which is every enum the manifest declares: exec-order, lint-review, tx-mode, and create-repo's required type.

The orb is generated at release time into a gitignored directory that no CI job reads, hence neither showed up.